### PR TITLE
Do not use __builtin_cpu_ on APPLE targets; clang wrongly believes it supports it

### DIFF
--- a/lib/keccak/keccak.c
+++ b/lib/keccak/keccak.c
@@ -278,7 +278,7 @@ static void keccakf1600_generic(uint64_t state[25])
 static void (*keccakf1600_best)(uint64_t[25]) = keccakf1600_generic;
 
 
-#if !defined(_MSC_VER) && defined(__x86_64__) && __has_attribute(target)
+#if !defined(_MSC_VER) && !defined(__APPLE__) && defined(__x86_64__) && __has_attribute(target)
 __attribute__((target("bmi,bmi2"))) static void keccakf1600_bmi(uint64_t state[25])
 {
     keccakf1600_implementation(state);


### PR DESCRIPTION
```
  = note: Undefined symbols for architecture x86_64:
            "___cpu_indicator_init", referenced from:
                _select_keccakf1600_implementation in libevmone_sys-9de5b3c41b60e993.rlib(keccak.c.o)
            "___cpu_model", referenced from:
                _select_keccakf1600_implementation in libevmone_sys-9de5b3c41b60e993.rlib(keccak.c.o)
          ld: symbol(s) not found for architecture x86_64
```

Without this change on macOS. 